### PR TITLE
Support icon size bigger than 99

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,10 +42,10 @@ const getParamKey = val => {
   const n = num(val)
   if (!val.length) {
     return null
-  } else if (isHex(val)) {
-    return { color: '#' + val }
   } else if (!isNaN(n)) {
     return { size: n }
+  } else if (isHex(val)) {
+    return { color: '#' + val }
   } else if (type === 'string' && !/\-/.test(val)) {
     return { [val]: true }
   } else if (type === 'string' && /\-/.test(val)) {


### PR DESCRIPTION
I move the check size conditional before hex to allow icon size bigger than 99.

`https://icon.now.sh/chevron/512/ff0000` now works